### PR TITLE
Freezing temperature exception: A warning window is opened when the temperature reach below 0 degree celsius

### DIFF
--- a/343Proj/src/commandlog.txt
+++ b/343Proj/src/commandlog.txt
@@ -391,3 +391,130 @@
 [SHC] All doors locked in the house
 [SHC] All lights turned off in the house
 [SHP] Adrien activated away mode.
+[Dashboard] A non-logged-in user pressed the edit profile button.
+[SHC] Profile logged in. Username is Adrien.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 2.0°C.
+[SHC] Window unlocked in Kitchen
+[Dashboard] Adrien has started the simulator.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[Dashboard] A non-logged-in user pressed the edit profile button.
+[SHC] Profile logged in. Username is Adrien.
+[Dashboard] Adrien has pressed the edit outside temperature button.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.0°C.
+[Dashboard] Adrien has started the simulator.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[Dashboard] A non-logged-in user pressed the edit profile button.
+[SHC] Profile logged in. Username is Adrien.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.0°C.
+[Dashboard] Adrien has started the simulator.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[Dashboard]  has pressed the edit time button.
+[Dashboard]  has pressed the edit outside temperature button.
+[Dashboard]  has pressed the edit location button.
+[Dashboard]  has pressed the edit outside temperature button.
+[Dashboard] A non-logged-in user pressed the edit profile button.
+[SHC] Profile logged in. Username is Adrien.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.0°C.
+[Dashboard] Adrien has started the simulator.
+[Dashboard] Adrien has pressed the edit outside temperature button.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[Dashboard] A non-logged-in user pressed the edit profile button.
+[SHC] Profile logged in. Username is Adrien.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.0°C.
+[Dashboard] Adrien has started the simulator.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[Dashboard]  has started the simulator.
+[SHH]  tried to edit the Kitchen's temperature but was denied!
+[Dashboard] A non-logged-in user pressed the edit profile button.
+[SHC] Profile logged in. Username is Adrien.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.0°C.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[Dashboard] A non-logged-in user pressed the edit profile button.
+[SHC] Profile logged in. Username is Adrien.
+[Dashboard] Adrien has pressed the edit outside temperature button.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.0°C.
+[Dashboard] Adrien has started the simulator.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[Dashboard] A non-logged-in user pressed the edit profile button.
+[SHC] Profile logged in. Username is Adrien.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.0°C.
+[Dashboard] Adrien pressed the edit profile button.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.0°C.
+[SHC] Window unlocked in Kitchen
+[Dashboard] Adrien has started the simulator.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.0°C.
+[Dashboard] Adrien has pressed the edit outside temperature button.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 9.9°C.
+[Dashboard] Adrien has pressed the edit outside temperature button.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[Dashboard] Adrien has stopped the simulator.
+[Dashboard] A non-logged-in user pressed the edit profile button.
+[SHC] Profile logged in. Username is Adrien.
+[Dashboard] Adrien has started the simulator.
+[Dashboard] Adrien has pressed the edit outside temperature button.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 2.0°C.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 2.9°C.
+[Dashboard] A non-logged-in user pressed the edit profile button.
+[SHC] Profile logged in. Username is Adrien.
+[SHC] All windows in the house locked.
+[SHC] All doors locked in the house
+[SHC] All lights turned off in the house
+[SHP] Adrien activated away mode.
+[SHP] Adrien deactivated away mode.
+[Dashboard] Adrien has started the simulator.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.0°C.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windowsin Kitchen to closed/off.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.0°C.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windowsin Kitchen to closed/off.
+[Dashboard] Adrien has stopped the simulator.
+[Dashboard] Adrien has started the simulator.
+[Dashboard] Adrien has pressed the edit outside temperature button.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.0°C.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[Dashboard] A non-logged-in user pressed the edit profile button.
+[SHC] Profile logged in. Username is Adrien.
+[Dashboard] Adrien has started the simulator.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.0°C.
+[Dashboard] Adrien has pressed the edit outside temperature button.
+[SHC] Window unlocked in Kitchen
+[Core] Adrien has set Windows in Kitchen to open/on.
+[SHH] Adrien is editing the Kitchen's temperature.
+[SHH] Adrien has changed the temperature of the Kitchen from 23.5°C to 1.9°C.
+[Dashboard] Adrien pressed the edit profile button.
+[Dashboard] Adrien has pressed the edit outside temperature button.

--- a/343Proj/src/utility/AlertManager.java
+++ b/343Proj/src/utility/AlertManager.java
@@ -2,10 +2,12 @@ package utility;
 
 import java.util.Optional;
 
+import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 
 public class AlertManager {
+	public static int numberOfAlertSent = 0; 
 	 /**
      * Opens a window to show if a command is successful
      */
@@ -27,14 +29,24 @@ public class AlertManager {
         Optional<ButtonType> result = alert.showAndWait();
     }
     
-    public static void freezingTemperatureAlert() {
-    	 Alert alert = new Alert(Alert.AlertType.WARNING,
-                 "Warning! The Room temperture has reached 0 Degrees Celsius. Please increase the Temperture.",
-                 ButtonType.CLOSE);
-         alert.setHeaderText(null);
-         Optional<ButtonType> result = alert.showAndWait();
+    /**
+     * This Alert is sent when a room reached zero degrees or below
+     */
+    public static void freezingTemperatureAlert(String roomName) {
+    	if(numberOfAlertSent < 1) {
+    		Alert alert = new Alert(Alert.AlertType.WARNING, "Warning! The " + roomName + " temperture has reached below 0 Degrees Celsius. Please increase the Temperture.",
+    			ButtonType.CLOSE);
+    		alert.setTitle(null);
+    		alert.setHeaderText(null);
+    		alert.show();
+    		numberOfAlertSent++;
+    	}   
     }
-    
+    /**
+     * This Alert is sent when a Room does not have a door or window and the user tries to open or close them.
+     * @param roomName
+     * @param item
+     */
     public static void ItemDoesNotExist (String roomName, String item) {
    	 Alert alert = new Alert(Alert.AlertType.WARNING,
                 "ERROR: The " + roomName + " does Not have a " + item,

--- a/343Proj/src/utility/TemperatureManager.java
+++ b/343Proj/src/utility/TemperatureManager.java
@@ -31,14 +31,21 @@ public class TemperatureManager implements WindowObserver {
         return instance;
     }
 
-    private TemperatureManager() {
-    }
+    private TemperatureManager() {}
 
     //Creating a timeline object to loop in intervals.
     public static Timeline temperatureTimeline;
 
     public static void initialize() {
         HomeController.windowWatcher.subscribe(TemperatureManager.getInstance());
+    }
+    public static void checkFreezingTemperature(Room room) {
+    	if(room.getInitialTemp() <= 0.0) {
+        	AlertManager.freezingTemperatureAlert(room.getRoomName());
+        }
+        else {
+        	AlertManager.numberOfAlertSent = 0;
+        }
     }
 
     // Method for changing the temperature of a single room in the house.
@@ -64,9 +71,8 @@ public class TemperatureManager implements WindowObserver {
                                         String formattedIncrementedTemperature = String.format("%.1f", (room.getInitialTemp()-0.1));
                                         room.setInitialTemp((Double.parseDouble(formattedIncrementedTemperature)));
                                     }
-                                    else if(room.getInitialTemp() == 0.0) {
-                                    	//AlertManager.freezingTemperatureAlert();
-                                    }
+                                    // This Check if roomTemperture drop below 0 degree celcius and sents a warning to the user about it.
+                                    checkFreezingTemperature(room);
                                 })
                         );
                         //Run the timeline indefinitely or until paused/stopped manually.


### PR DESCRIPTION
This can be tested by doing a what @AdrienKamran and I implemented in #56. After Logging in you can start the simulation and set the outsideTemperture to 0 or below 0. Then after, open the window of any room and wait until the roomTemperature reaches zero. Once it reaches zero, a Warning Alert window will open up. Asking you to increase the temperture. This doesnot affect the TempetureManager timeline. The roomTemperture still keeps falling.
This closes Issue #52 